### PR TITLE
Refactor layout to include it on every page

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,4 @@
-/**
- * Implement Gatsby's Browser APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/browser-apis/
- */
+const React = require('react')
+const Layout = require('./src/components/layout').default
 
-// You can delete this file if you're not using it
+exports.wrapRootElement = ({ element }) => <Layout>{element}</Layout>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -10,7 +10,12 @@ const Layout = ({ children }) => (
     <Header />
     <div>
       <Content>{children}</Content>
-      <Footer>Made with ❤️</Footer>
+      <Footer>
+        © {new Date().getFullYear()}, Built with love
+        <span rol="img" aria-label="heart-emoji">
+          ❤️
+        </span>
+      </Footer>
     </div>
   </>
 )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,16 +1,16 @@
-import React from "react"
-import { Link } from "gatsby"
+import React from 'react'
+import { Link } from 'gatsby'
 
-import { Layout, SEO } from "../components"
+import { Layout, SEO } from '../components'
 
 const IndexPage = () => (
-  <Layout>
+  <>
     <SEO title="Home" />
     <h1>Hi people</h1>
     <p>Welcome to your new Gatsby site.</p>
     <p>Now go build something great.</p>
     <Link to="/thanks">Go to thanks</Link>
-  </Layout>
+  </>
 )
 
 export default IndexPage

--- a/src/pages/page-2.js
+++ b/src/pages/page-2.js
@@ -1,16 +1,16 @@
-import React from "react"
-import { Link } from "gatsby"
+import React from 'react'
+import { Link } from 'gatsby'
 
-import Layout from "../components/layout"
-import SEO from "../components/seo"
+import Layout from '../components/layout'
+import SEO from '../components/seo'
 
 const SecondPage = () => (
-  <Layout>
+  <>
     <SEO title="Page two" />
     <h1>Hi from the second page</h1>
     <p>Welcome to page 2</p>
     <Link to="/">Go back to the homepage</Link>
-  </Layout>
+  </>
 )
 
 export default SecondPage


### PR DESCRIPTION
It was used Gatsby API to add layout to every page without add the
`<Layout>` tag every-time.